### PR TITLE
Use failure crate for errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 [dependencies]
 bitcoin = "0.11.0"
 lightning = { git = "https://github.com/tamasblummer/rust-lightning", branch = "master" }
+failure = "0.1.1"
 tokio = "0.1"
 tokio-io = "0.1"
 futures = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 //limitations under the License.
 extern crate bitcoin;
 extern crate bytes;
+#[macro_use]
+extern crate failure;
 extern crate futures;
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
This PR proposes to switch to [`failure`](https://github.com/rust-lang-nursery/failure) crate for handing errors.