### PR TITLE
Executable takes db path and peer addresses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ readme = "README.md"
 name = "bitcoin_spv"
 path = "src/lib.rs"
 
+[[bin]]
+name = "bitcoin_spv"
+path = "src/bin/main.rs"
+
 [dependencies]
 bitcoin = "0.13"
 bitcoin-chain = { git = "https://github.com/rust-bitcoin/rust-bitcoin-chain", branch = "master" }

--- a/src/bin/args.rs
+++ b/src/bin/args.rs
@@ -2,15 +2,15 @@ use std::env::args;
 
 // Returns key-value zipped iterator.
 fn zipped_args() -> impl Iterator<Item = (String, String)> {
-    let key_args = args()
-        .filter(|arg| arg.starts_with("-"))
-        .map(|mut arg| arg.split_off(1));
+    let key_args = args().filter(|arg| arg.starts_with("-")).map(|mut arg| arg.split_off(1));
     let val_args = args().skip(1).filter(|arg| !arg.starts_with("-"));
     key_args.zip(val_args)
 }
 
 pub fn find_arg(key: &str) -> Option<String> {
-    zipped_args()
-        .find(|&(ref k, _)| k.as_str() == key)
-        .map(|(_, v)| v)
+    zipped_args().find(|&(ref k, _)| k.as_str() == key).map(|(_, v)| v)
+}
+
+pub fn find_args(key: &str) -> Vec<String> {
+    zipped_args().filter(|&(ref k, _)| k.as_str() == key).map(|(_, v)| v).collect()
 }

--- a/src/bin/args.rs
+++ b/src/bin/args.rs
@@ -1,0 +1,16 @@
+use std::env::args;
+
+// Returns key-value zipped iterator.
+fn zipped_args() -> impl Iterator<Item = (String, String)> {
+    let key_args = args()
+        .filter(|arg| arg.starts_with("-"))
+        .map(|mut arg| arg.split_off(1));
+    let val_args = args().skip(1).filter(|arg| !arg.starts_with("-"));
+    key_args.zip(val_args)
+}
+
+pub fn find_arg(key: &str) -> Option<String> {
+    zipped_args()
+        .find(|&(ref k, _)| k.as_str() == key)
+        .map(|(_, v)| v)
+}

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -31,8 +31,7 @@ use std::env;
 /// simple test drive that connects to a local bitcoind
 pub fn main() {
     simple_logger::init_with_level(Level::Info).unwrap();
-    let mut peers = Vec::new();
-    peers.push(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8333));
+    let peers = get_peers();
     if let Some(path) = args::find_arg("db") {
         let spv = SPV::new("/rust-spv:0.1.0/".to_string(), Network::Bitcoin, Path::new(path.as_str())).unwrap();
         spv.run(peers, 1).unwrap();
@@ -43,3 +42,8 @@ pub fn main() {
     }
 }
 
+use std::str::FromStr;
+
+fn get_peers() -> Vec<SocketAddr> {
+    args::find_args("p").iter().map(|s| SocketAddr::from_str(s).unwrap()).collect()
+}

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -19,6 +19,8 @@ extern crate log;
 extern crate rand;
 extern crate simple_logger;
 
+mod args;
+
 use bitcoin::network::constants::Network;
 use bitcoin_spv::spv::SPV;
 use log::Level;
@@ -28,12 +30,11 @@ use std::env;
 
 /// simple test drive that connects to a local bitcoind
 pub fn main() {
-    let args: Vec<String> = env::args().collect();
     simple_logger::init_with_level(Level::Info).unwrap();
     let mut peers = Vec::new();
     peers.push(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8333));
-    if args.len() > 1 {
-        let spv = SPV::new("/rust-spv:0.1.0/".to_string(), Network::Bitcoin, Path::new(args[1].as_str())).unwrap();
+    if let Some(path) = args::find_arg("db") {
+        let spv = SPV::new("/rust-spv:0.1.0/".to_string(), Network::Bitcoin, Path::new(path.as_str())).unwrap();
         spv.run(peers, 1).unwrap();
     }
     else {


### PR DESCRIPTION
My English is probably poor. I apologize it.

---

This is just a tiny change but first step to make executable richer.

- Add `args` module for bin directory
- Executable takes `-<key> <value>` style argument
- User can specify peer address connecting to by `-p` option.
- User can specify db path by `-db` option.