### PR TITLE
Switch to crates version of rust-lightning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/bin/main.rs"
 bitcoin = { version = "0.15", features = ["bitcoinconsensus"] }
 bitcoin-chain = "0.3.1"
 hammersbald = { version="1.1", features = ["bitcoin_support"] }
-lightning = { git = "https://github.com/rust-bitcoin/rust-lightning", branch = "master" }
+lightning = "0.0.7"
 mio = "0.6"
 rand = "0.5"
 siphasher = "0.2"


### PR DESCRIPTION
The API should be more than stable enough now to just take changes when they get pushed on crates instead of trying to follow a master branch.